### PR TITLE
Code improvements: fix trait bounds, error messages, and unused imports

### DIFF
--- a/crates/jagged/src/config.rs
+++ b/crates/jagged/src/config.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 use crate::JaggedEvalConfig;
 
-pub trait JaggedConfig: 'static + Clone + Send + Clone + Serialize + DeserializeOwned {
+pub trait JaggedConfig: 'static + Clone + Send + Serialize + DeserializeOwned {
     type F: Field;
     type EF: ExtensionField<Self::F>;
 

--- a/crates/jagged/src/verifier.rs
+++ b/crates/jagged/src/verifier.rs
@@ -2,7 +2,6 @@ use hypercube_multilinear::{full_geq, Evaluations, Mle, Point};
 use hypercube_stacked::{StackedPcsProof, StackedPcsVerifier};
 use hypercube_sumcheck::{partially_verify_sumcheck_proof, PartialSumcheckProof, SumcheckError};
 use p3_challenger::FieldChallenger;
-use p3_field::AbstractField;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use thiserror::Error;

--- a/crates/merkle-tree/src/tcs.rs
+++ b/crates/merkle-tree/src/tcs.rs
@@ -39,8 +39,8 @@ pub struct MerkleTreeTcs<M: MerkleTreeConfig> {
 
 #[derive(Debug, Clone, Copy, Error)]
 pub enum MerkleTreeTcsError {
-    #[error("root mismatch")]
-    RootMismatch,
+    #[error("Merkle tree root mismatch: expected {expected} but got {actual}")]
+    RootMismatch { expected: String, actual: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sumcheck/src/verifier.rs
+++ b/crates/sumcheck/src/verifier.rs
@@ -10,8 +10,8 @@ use crate::PartialSumcheckProof;
 pub enum SumcheckError {
     #[error("invalid proof shape")]
     InvalidProofShape,
-    #[error("sumcheck round inconsistency")]
-    SumcheckRoundInconsistency,
+    #[error("sumcheck round inconsistency: expected value {expected} but got {actual}")]
+    SumcheckRoundInconsistency { expected: String, actual: String },
     #[error("inconsistency of prover message with claimed sum")]
     InconsistencyWithClaimedSum,
     #[error("inconsistency of proof with evaluation claim")]


### PR DESCRIPTION
Code Improvements for SP1 Hypercube Verifier

This PR makes several code quality improvements to the codebase:

Changes:

1. Fixed duplicate `Clone` trait bound in the `JaggedConfig` trait definition
2. Improved error messages in:
   - `SumcheckRoundInconsistency` to include expected and actual values
   - `RootMismatch` to include expected and actual Merkle tree roots
3. Removed unused `AbstractField` import in `jagged/src/verifier.rs`

These changes improve code clarity, error reporting, and remove redundancy without altering functionality.